### PR TITLE
revert incorrect change to applying weights

### DIFF
--- a/regrid.py
+++ b/regrid.py
@@ -202,7 +202,10 @@ def apply_weights(src, dest_shape, n_s, n_b, row, col, s):
     dest = np.zeros(dest_shape).flatten()
     src = src.flatten()
 
-    dest[row[1:n_s]-1] = dest[row[1:n_s]-1] + s[1:n_s]*src[col[1:n_s]-1]
+    weighted_src =  s[0:n_s]*src[col[0:n_s]-1]
+
+    for i in range(0, n_s):
+        dest[row[i]-1] = dest[row[i]-1] + weighted_src[i]
 
     return dest.reshape(dest_shape)
 


### PR DESCRIPTION
Addresses https://github.com/ACCESS-NRI/access-om3-configs/issues/580

Using this change new gives identical temp and salinity as the previous correct version (`/g/data/vk83/prerelease/configurations/inputs/access-om3/mom/initial_conditions/global.25km/2025.03.19/ocean_temp_salt.res.nc`)