### PR TITLE
Allow for native application of regridding weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ $ conda env create -f regrid.yml
 $ source activate regrid
 ```
 
+## Pythran
+
+Install the `pythran` package into your Python environment and run
+```bash
+$ pythran apply_weights.py
+```
+
+to build the native-code extension for faster weight application.
+
 ## ESMF dependencies
 
 Install ESMF_RegridWeightGen. ESMF releases can be found [here](http://www.earthsystemmodeling.org/download/data/releases.shtml).

--- a/apply_weights.py
+++ b/apply_weights.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+#pythran export apply_weights(float64[:,:], (int, int), int, int, int32[:], int32[:], float64[:])
+def apply_weights(src, dest_shape, n_s, n_b, row, col, s):
+    """
+    Apply ESMF regridding weights.
+    """
+
+    dest = np.zeros(dest_shape).flatten()
+    src = src.flatten()
+
+    weighted_src =  s[0:n_s]*src[col[0:n_s]-1]
+
+    for i in range(0, n_s):
+        dest[row[i]-1] = dest[row[i]-1] + weighted_src[i]
+
+    return dest.reshape(dest_shape)

--- a/grid.py
+++ b/grid.py
@@ -64,7 +64,7 @@ class Grid(object):
         # Set grid corners, we do these one corner at a time. Start at the 
         # bottom left and go anti-clockwise. This is the SCRIP convention.
         clon = np.empty((self.num_lat_points, self.num_lon_points, 4))
-        clon[:] = np.NAN
+        clon[:] = np.nan
         clon[:,:,0] = x - dx_half
         clon[:,:,1] = x + dx_half
         clon[:,:,2] = x + dx_half
@@ -72,7 +72,7 @@ class Grid(object):
         assert(not np.isnan(np.sum(clon)))
 
         clat = np.empty((self.num_lat_points, self.num_lon_points, 4))
-        clat[:] = np.NAN
+        clat[:] = np.nan
         clat[:,:,0] = y - dy_half
         clat[:,:,1] = y - dy_half
         clat[:,:,2] = y + dy_half

--- a/mom_grid.py
+++ b/mom_grid.py
@@ -48,7 +48,7 @@ class MomGrid(Grid):
         # Corners of t points. Index 0 is bottom left and then
         # anti-clockwise.
         clon = np.empty((self.x_t.shape[0], self.x_t.shape[1], 4))
-        clon[:] = np.NAN
+        clon[:] = np.nan
         clon[:,:,0] = x[0:-1:2,0:-1:2]
         clon[:,:,1] = x[0:-1:2,2::2]
         clon[:,:,2] = x[2::2,2::2]
@@ -56,7 +56,7 @@ class MomGrid(Grid):
         assert(not np.isnan(np.sum(clon)))
 
         clat = np.empty((self.x_t.shape[0], self.x_t.shape[1], 4))
-        clat[:] = np.NAN
+        clat[:] = np.nan
         clat[:,:,0] = y[0:-1:2,0:-1:2]
         clat[:,:,1] = y[0:-1:2,2::2]
         clat[:,:,2] = y[2::2,2::2]

--- a/regrid.py
+++ b/regrid.py
@@ -6,12 +6,13 @@ import sys, os
 import tempfile
 import argparse
 import numpy as np
-import numba
 import copy
 import subprocess as sp
 import netCDF4 as nc
 from numpy import interp
 from scipy import ndimage as nd
+
+from .apply_weights import apply_weights
 
 from .mom_grid import MomGrid
 from .mom1_grid import Mom1Grid
@@ -193,21 +194,6 @@ def extend_src_data(src_data, src_grid, global_src_grid, temp_or_salt):
                                       global_src_grid)
 
     return global_src_data
-
-def apply_weights(src, dest_shape, n_s, n_b, row, col, s):
-    """
-    Apply ESMF regridding weights.
-    """
-
-    dest = np.zeros(dest_shape).flatten()
-    src = src.flatten()
-
-    weighted_src =  s[0:n_s]*src[col[0:n_s]-1]
-
-    for i in range(0, n_s):
-        dest[row[i]-1] = dest[row[i]-1] + weighted_src[i]
-
-    return dest.reshape(dest_shape)
 
 
 def regrid(regrid_weights, src_data, dest_grid):


### PR DESCRIPTION
This moves the `apply_weights` function out to its own module, and adds a signature so it can be compiled to native code with [pythran](https://github.com/serge-sans-paille/pythran). If the native module isn't compiled, it will transparently fall back to the Python implementation.

I haven't included any build system integration here: with pythran installed you can simply run `pythran apply_weights.py`, and it will create a shared library something like `apply_weights.cpython-312-x86_64-linux-gnu.so`.

Running `makeic.py` from the [initial conditions repository](https://github.com/ACCESS-NRI/initial_conditions_access-om3) on a 1deg global grid for a single monthly averaged file goes from about 230s to 50s using this change on my machine.